### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1375,35 +1375,6 @@ def download_molecules():
                         'success': False,
                         'error': 'Invalid entry in "names". Only alphanumeric, underscores, and hyphens allowed.'
                     }), 400
-        if count is not None:
-            if not isinstance(count, int):
-                return jsonify({'success': False, 'error': 'count must be an integer'}), 400
-            count = min(max(count, 1), 100000)  # Clamp to reasonable max
-        
-        # Validate names
-        if names:
-            if not isinstance(names, list):
-                return jsonify({'success': False, 'error': 'names must be a list'}), 400
-            if len(names) > 200:
-                return jsonify({
-                    'success': False,
-                    'error': 'Too many names (max 200)'
-                }), 400
-            if not all(isinstance(n, str) for n in names):
-                return jsonify({'success': False, 'error': 'names must be a list of strings'}), 400
-            if any(len(n) > 200 for n in names):
-                return jsonify({
-                    'success': False,
-                    'error': 'Name too long (max 200 chars)'
-                }), 400
-            # Additional validation: allow only safe characters in names
-            for n in names:
-                if not ALLOWED_NAME_PATTERN.match(n):
-                    return jsonify({
-                        'success': False,
-                        'error': f"Invalid characters detected in name: '{n}'. Allowed: letters, numbers, spaces, (), -, _, comma, period, apostrophe."
-                    }), 400
-        
         if not count and not names and not full_file:
             return jsonify({
                 'success': False,

--- a/backend/api.py
+++ b/backend/api.py
@@ -1348,7 +1348,7 @@ def download_molecules():
         MAX_COUNT = 1000
         try:
             count_int = int(count) if count is not None else None
-        except Exception:
+        except (ValueError, TypeError):
             return jsonify({
                 'success': False,
                 'error': 'Parameter "count" must be an integer.'

--- a/backend/api.py
+++ b/backend/api.py
@@ -1336,15 +1336,45 @@ def download_molecules():
         source = data.get('source', 'pubchem')
         names = data.get('names', [])
         full_file = data.get('full_file', False)
-        
-        # Validate inputs to prevent unbounded operations
+
+        # Validate source from allowlist (already present)
         if source not in {'pubchem', 'chembl', 'zinc'}:
             return jsonify({
                 'success': False,
                 'error': 'Invalid source. Must be one of: pubchem, chembl, zinc'
             }), 400
-        
+
         # Validate and clamp count
+        MAX_COUNT = 1000
+        try:
+            count_int = int(count) if count is not None else None
+        except Exception:
+            return jsonify({
+                'success': False,
+                'error': 'Parameter "count" must be an integer.'
+            }), 400
+        if count_int is not None:
+            if not (1 <= count_int <= MAX_COUNT):
+                return jsonify({
+                    'success': False,
+                    'error': f'Parameter "count" must be between 1 and {MAX_COUNT}.'
+                }), 400
+        count = count_int  # Use the validated int value from now on
+
+        # Validate names: must be a list of allowed names (alphanumeric/underscore)
+        if names:
+            if not isinstance(names, list):
+                return jsonify({
+                    'success': False,
+                    'error': 'Parameter "names" must be a list.'
+                }), 400
+            allowed_name_pattern = re.compile(r'^[\w\-]+$')
+            for n in names:
+                if not isinstance(n, str) or not allowed_name_pattern.match(n):
+                    return jsonify({
+                        'success': False,
+                        'error': 'Invalid entry in "names". Only alphanumeric, underscores, and hyphens allowed.'
+                    }), 400
         if count is not None:
             if not isinstance(count, int):
                 return jsonify({'success': False, 'error': 'count must be an integer'}), 400

--- a/backend/api.py
+++ b/backend/api.py
@@ -24,6 +24,8 @@ except ImportError:
 
 # Compiled regex for validating names in download endpoints
 ALLOWED_NAME_PATTERN = re.compile(r"^[A-Za-z0-9 \-_\(\),\.']+$")
+# Stricter pattern for comma-joined names (no spaces/commas) to avoid injection when joining
+ALLOWED_COMPACT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 # Allow a restricted, human-friendly disease string (letters, numbers, spaces, ()-_,.' and comma)
 ALLOWED_DISEASE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 \-_\(\),\.']{0,199}$")
 # Detect control characters that should never be accepted in user input
@@ -1368,9 +1370,23 @@ def download_molecules():
                     'success': False,
                     'error': 'Parameter "names" must be a list.'
                 }), 400
-            allowed_name_pattern = re.compile(r'^[\w\-]+$')
+            if len(names) > 200:
+                return jsonify({
+                    'success': False,
+                    'error': 'Too many names (max 200)'
+                }), 400
             for n in names:
-                if not isinstance(n, str) or not allowed_name_pattern.match(n):
+                if not isinstance(n, str):
+                    return jsonify({
+                        'success': False,
+                        'error': 'All entries in "names" must be strings.'
+                    }), 400
+                if len(n) > 200:
+                    return jsonify({
+                        'success': False,
+                        'error': 'Name too long (max 200 chars)'
+                    }), 400
+                if not ALLOWED_COMPACT_NAME_PATTERN.match(n):
                     return jsonify({
                         'success': False,
                         'error': 'Invalid entry in "names". Only alphanumeric, underscores, and hyphens allowed.'


### PR DESCRIPTION
Potential fix for [https://github.com/greenrobotllc/bio-neighbor/security/code-scanning/1](https://github.com/greenrobotllc/bio-neighbor/security/code-scanning/1)

To fix this error, all user-provided values that are used in constructing the command (`cmd`) must be strictly validated or restricted:

- For the `count` parameter, ensure that it is an integer in a safe, bounded range (e.g., 1–1000). If not, reject the request.
- For the `names` parameter, validate that it is a list of allowed (safe) characters only (e.g., matches a regex of allowed names/symbols), and none of the names contain unexpected or problematic characters (such as spaces, shell metacharacters, path separators, etc.).
- For `source`, the allowlist check already exists.
- After input sanitization, safely build the command as a list of arguments (as already done) and pass it to `subprocess.Popen`. There is no need to quote the arguments as subprocess will pass them as arguments, not as a command line string.
- Provide clear error responses for invalid input.
- Make all checks _before_ command construction.

The necessary changes:
- Add or improve validation of `count` _before_ it's used.
- Add validation for each member of `names` using a whitelist regex and prevent empty or malicious names.
- Reject the request with a clear error if validation fails, before constructing or running `cmd`.

You may need to add a regex for allowed molecule names and clamp count to a safe integer range.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter input validation for molecule downloads: count must be an integer between 1 and 1000 and is normalized for downstream use.
  * Names must be a list of strings meeting per-name length and character rules; invalid inputs return clear 400 errors.
  * Validation now runs earlier for faster fail-fast behavior and clearer error messages.
  * Existing source allowlist checks retained and aligned with new validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->